### PR TITLE
use map; use strings.TrimSpace() instead of strings.Trim(); comments

### DIFF
--- a/slugify.go
+++ b/slugify.go
@@ -5,44 +5,44 @@ import (
 	"strings"
 )
 
-var replacements = map[string]string{
-	"á": "a",
-	"à": "a",
-	"ä": "a",
-	"â": "a",
-	"é": "e",
-	"è": "e",
-	"ë": "e",
-	"ê": "e",
-	"í": "i",
-	"ì": "i",
-	"i": "i",
-	"î": "i",
-	"ó": "o",
-	"ò": "o",
-	"ö": "o",
-	"ő": "o",
-	"ô": "o",
-	"ú": "u",
-	"ù": "u",
-	"ü": "u",
-	"ű": "u",
-	"ç": "c",
-	"·": "-",
-	"/": "-",
-	"_": "-",
-	",": "-",
-	":": "-",
-	";": "-",
+var replacements = map[rune]string{
+	'á': "a",
+	'à': "a",
+	'ä': "a",
+	'â': "a",
+	'é': "e",
+	'è': "e",
+	'ë': "e",
+	'ê': "e",
+	'í': "i",
+	'ì': "i",
+	'i': "i",
+	'î': "i",
+	'ó': "o",
+	'ò': "o",
+	'ö': "o",
+	'ő': "o",
+	'ô': "o",
+	'ú': "u",
+	'ù': "u",
+	'ü': "u",
+	'ű': "u",
+	'ç': "c",
+	'·': "-",
+	'/': "-",
+	'_': "-",
+	',': "-",
+	':': "-",
+	';': "-",
 }
 
 func S(str string) string {
-	str = strings.ToLower(strings.TrimSpace(str)) // Trim, then Lower-Case
+	str = strings.ToLower(strings.TrimSpace(str)) // Trim all whitespace, then Lower-Case
 	newstr := ""
 
 	// Iterate over string, for each character check if there is a replacement, if so, append it to newstr, if not, append original value to newstr
 	for _, char := range str {
-		if replacement, ok := replacements[string(char)]; ok {
+		if replacement, ok := replacements[char]; ok {
 			newstr += replacement
 		} else {
 			newstr += string(char)

--- a/slugify_test.go
+++ b/slugify_test.go
@@ -1,22 +1,21 @@
-package slugify_test
+package slugify
 
 import (
-	"../slugify"
 	"testing"
 )
 
 // Test Slugify
 func TestSlugify(t *testing.T) {
-	if slugify.S("Hello World") != "hello-world" {
+	if S("Hello World") != "hello-world" {
 		t.Fail()
 	}
-	if slugify.S("Hello World69") != "hello-world69" {
+	if S("Hello World69") != "hello-world69" {
 		t.Fail()
 	}
-	if slugify.S("Hello           World????????") != "hello-world-" {
+	if S("Hello           World????????") != "hello-world-" {
 		t.Fail()
 	}
-	if slugify.S("aáäâeéëeiíiîoóöőôuúüűunç·/_,:;") != "aaaaeeeeiiiiooooouuuuunc-" {
+	if S("aáäâeéëeiíiîoóöőôuúüűunç·/_,:;") != "aaaaeeeeiiiiooooouuuuunc-" {
 		t.Fail()
 	}
 }


### PR DESCRIPTION
sooo, I had some spare time and made the switch to a map as you suggested: slugify now uses a map. this gives better performance. also, strings.Trim() -> strings.TrimWhitespace() plus some comment fixes/additions. Also, I cleaned up the _test.go file (was a bit messy, different package, then imported slugify, then called slugify.S() every time). 
